### PR TITLE
Basis Set Improvements

### DIFF
--- a/example_scripts/full-rhf.jl
+++ b/example_scripts/full-rhf.jl
@@ -45,12 +45,17 @@ function full_rhf(input_file)
     if driver == "energy"
       if model["method"] == "RHF"
         #== perform scf calculation ==#
-        rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis, keywords["scf"]; 
-          output="verbose") 
-     
+        if haskey(keywords, "scf")
+          rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis, keywords["scf"]; 
+            output="verbose") 
+        else
+          rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis; 
+            output="verbose") 
+        end
+    
         #== compute molecular properties such as dipole moment ==#
-        properties = JuliaChem.JCProperties.run(mol, basis, rhf_energy, keywords["prop"], 
-          output="verbose")
+        properties = JuliaChem.JCProperties.run(mol, basis, rhf_energy, 
+          keywords["prop"]; output="verbose")
       else
         throw("Exception: Methods other than RHF are not supported yet!")
       end  

--- a/example_scripts/minimal-rhf-repl.jl
+++ b/example_scripts/minimal-rhf-repl.jl
@@ -19,8 +19,13 @@ function minimal_rhf(input_file)
     #JuliaChem.JCMolecule.run(mol)
 
     #== perform scf calculation ==#
-    rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis, keywords["scf"]; 
-      output="verbose") 
+    if haskey(keywords, "scf")
+      rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis, keywords["scf"];
+        output="verbose")
+    else
+      rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis;
+        output="verbose")
+    end
 
     #display(rhf_energy["Density"]); println()
     #display(rhf_energy["Energy-Weighted Density"]); println()

--- a/example_scripts/minimal-rhf-repl.jl
+++ b/example_scripts/minimal-rhf-repl.jl
@@ -10,7 +10,7 @@ function minimal_rhf(input_file)
   try
     #== read in input file ==#
     molecule, driver, model, keywords = JuliaChem.JCInput.run(input_file;       
-      output="verbose")       
+      output="none")       
     
     #== generate basis set ==#
     mol, basis = JuliaChem.JCBasis.run(molecule, model; 
@@ -19,6 +19,7 @@ function minimal_rhf(input_file)
     #JuliaChem.JCMolecule.run(mol)
 
     #== perform scf calculation ==#
+    rhf_energy = Dict()
     if haskey(keywords, "scf")
       rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis, keywords["scf"];
         output="verbose")

--- a/example_scripts/minimal-rhf-repl.py
+++ b/example_scripts/minimal-rhf-repl.py
@@ -19,9 +19,15 @@ def minimal_rhf(input_file):
     mol, basis = JuliaChem.JCBasis.run(molecule, model, output="none")
 
     #== perform scf calculation ==#
-    scf = JuliaChem.JCRHF.run(mol, basis, keywords["scf"], output="minimal")
+    rhf_energy = {}
+    if "scf" in keywords:
+      rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis, keywords["scf"],
+        output="verbose")
+    else:
+      rhf_energy = JuliaChem.JCRHF.Energy.run(mol, basis,
+        output="verbose")
 
-    return scf
+    return rhf_energy 
   except Exception as e:                                                        
     bt = Base.catch_backtrace()                                                 
     msg = Base.sprint(Base.showerror, e, bt)

--- a/src/basis/JCBasis.jl
+++ b/src/basis/JCBasis.jl
@@ -115,9 +115,9 @@ function run(molecule, model; output="none")
         bsed["$symbol/$basis"])
 
       #== process basis set values into shell objects ==#
-      if MPI.Comm_rank(comm) == 0 && output == "verbose"
-        println("ATOM #$atom_idx ($symbol):") 
-      end
+      #if MPI.Comm_rank(comm) == 0 && output == "verbose"
+      #  println("ATOM #$atom_idx ($symbol):") 
+      #end
       
       for shell_num::Int64 in 1:length(shells)
         new_shell_dict::Dict{String,Any} = shells["$shell_num"]
@@ -134,11 +134,12 @@ function run(molecule, model; output="none")
         if new_shell_am == -1
           #== s component ==#
           if MPI.Comm_rank(comm) == 0 && output == "verbose"
-            println("L (s)")
+            println("Atom $atom_idx ($symbol) Shell $shell_num (L (s))" 
+              * " Exponents and Coefficients:")
             pretty_table(hcat(collect(1:nprim),new_shell_exp, 
               new_shell_coeff[1:nprim]), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
-              formatters = ft_printf("%5.15f", [2,3]) )
+              formatters = ft_printf("%5.8f", [2,3]) )
           end 
 
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number, 
@@ -157,11 +158,12 @@ function run(molecule, model; output="none")
 
           #== p component ==#
           if MPI.Comm_rank(comm) == 0 && output == "verbose"
-            println("L (p)")
+            println("Atom $atom_idx ($symbol) Shell $shell_num (L (p))" 
+             * " Exponents and Coefficients:")
             pretty_table(hcat(collect(1:nprim),new_shell_exp, 
               new_shell_coeff[(nprim+1):ncoeff]), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
-              formatters = ft_printf("%5.15f", [2,3]) )
+              formatters = ft_printf("%5.8f", [2,3]) )
           end 
 
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number,
@@ -180,11 +182,14 @@ function run(molecule, model; output="none")
         #== otherwise accept shell as is ==#
         else 
           if MPI.Comm_rank(comm) == 0 && output == "verbose"
-            println(new_shell_dict["Shell Type"])
+            shell_type = new_shell_dict["Shell Type"]
+            println("Atom $atom_idx ($symbol) Shell $shell_num ($shell_type)"
+              * " Exponents and Coefficients:")
+     
             pretty_table(hcat(collect(1:nprim),new_shell_exp, 
               new_shell_coeff), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
-              formatters = ft_printf("%5.15f", [2,3]) )
+              formatters = ft_printf("%5.8f", [2,3]) )
           end 
 
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number,

--- a/src/basis/JCBasis.jl
+++ b/src/basis/JCBasis.jl
@@ -123,30 +123,32 @@ function run(molecule, model; output="none")
         new_shell_dict::Dict{String,Any} = shells["$shell_num"]
 
         new_shell_am::Int64 = shell_am_mapping[new_shell_dict["Shell Type"]]
-        new_shell_exp::Vector{Float64} = new_shell_dict["Exponents"]
-        new_shell_coeff::Array{Float64} = new_shell_dict["Coefficients"]
+        
+        new_shell_exp = new_shell_dict["Exponents"]
+        nprim = length(new_shell_exp)
+        
+        new_shell_coeff = new_shell_dict["Coefficients"]
+        ncoeff = length(new_shell_coeff)
 
         #== if L shell, divide up ==# 
         if new_shell_am == -1
           #== s component ==#
           if MPI.Comm_rank(comm) == 0 && output == "verbose"
             println("L (s)")
-            pretty_table(hcat(collect(1:length(new_shell_exp)),new_shell_exp, 
-              new_shell_coeff[:,1]), 
+            pretty_table(hcat(collect(1:nprim),new_shell_exp, 
+              new_shell_coeff[1:nprim]), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
               formatters = ft_printf("%5.6f", [2,3]) )
           end 
 
-          new_shell_nprim = size(new_shell_exp)[1]
-
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number, 
-            new_shell_exp, new_shell_coeff[:,1],
-            atom_center, 1, size(new_shell_exp)[1], pos, true)
+            new_shell_exp, new_shell_coeff[1:nprim],
+            atom_center, 1, nprim, pos, true)
           push!(basis_set_shells, new_shell)
           #display(new_shell_coeff[:,1])
           if !shells_cxx_added[atomic_number+1]
             push!(shells_cxx[atomic_number+1], JERI.create_shell(0, 
-              new_shell_exp, new_shell_coeff[:,1], atom_center))
+              new_shell_exp, new_shell_coeff[1:nprim], atom_center))
           end
 
           basis_set_norb += 1 
@@ -156,22 +158,20 @@ function run(molecule, model; output="none")
           #== p component ==#
           if MPI.Comm_rank(comm) == 0 && output == "verbose"
             println("L (p)")
-            pretty_table(hcat(collect(1:length(new_shell_exp)),new_shell_exp, 
-              new_shell_coeff[:,2]), 
+            pretty_table(hcat(collect(1:nprim),new_shell_exp, 
+              new_shell_coeff[(nprim+1):ncoeff]), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
               formatters = ft_printf("%5.6f", [2,3]) )
           end 
 
-          new_shell_nprim = size(new_shell_exp)[1]
-
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number,
-            new_shell_exp, new_shell_coeff[:,2],
-            atom_center, 2, size(new_shell_exp)[1], pos, true)
+            new_shell_exp, new_shell_coeff[(nprim+1):ncoeff],
+            atom_center, 2, nprim, pos, true)
           push!(basis_set_shells,new_shell)
           #display(new_shell_coeff[:,2])
           if !shells_cxx_added[atomic_number+1]
             push!(shells_cxx[atomic_number+1], JERI.create_shell(1, 
-              new_shell_exp, new_shell_coeff[:,2], atom_center))
+              new_shell_exp, new_shell_coeff[(nprim+1):ncoeff], atom_center))
           end
 
           basis_set_norb += 3 
@@ -181,23 +181,19 @@ function run(molecule, model; output="none")
         else 
           if MPI.Comm_rank(comm) == 0 && output == "verbose"
             println(new_shell_dict["Shell Type"])
-            pretty_table(hcat(collect(1:length(new_shell_exp)),new_shell_exp, 
+            pretty_table(hcat(collect(1:nprim),new_shell_exp, 
               new_shell_coeff), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
               formatters = ft_printf("%5.6f", [2,3]) )
           end 
 
-          new_shell_nprim = size(new_shell_exp)[1]
-          new_shell_coeff_array = reshape(new_shell_coeff,
-            (length(new_shell_coeff),))       
-
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number,
-            new_shell_exp, deepcopy(new_shell_coeff_array),
-            atom_center, new_shell_am, size(new_shell_exp)[1], pos, true)
+            new_shell_exp, deepcopy(new_shell_coeff),
+            atom_center, new_shell_am, nprim, pos, true)
           push!(basis_set_shells,new_shell)
           if !shells_cxx_added[atomic_number+1]
             push!(shells_cxx[atomic_number+1], JERI.create_shell(new_shell_am-1, 
-              new_shell_exp, new_shell_coeff_array, atom_center))
+              new_shell_exp, new_shell_coeff, atom_center))
           end 
 
           basis_set_norb += new_shell.nbas

--- a/src/basis/JCBasis.jl
+++ b/src/basis/JCBasis.jl
@@ -138,7 +138,7 @@ function run(molecule, model; output="none")
             pretty_table(hcat(collect(1:nprim),new_shell_exp, 
               new_shell_coeff[1:nprim]), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
-              formatters = ft_printf("%5.6f", [2,3]) )
+              formatters = ft_printf("%5.15f", [2,3]) )
           end 
 
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number, 
@@ -161,7 +161,7 @@ function run(molecule, model; output="none")
             pretty_table(hcat(collect(1:nprim),new_shell_exp, 
               new_shell_coeff[(nprim+1):ncoeff]), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
-              formatters = ft_printf("%5.6f", [2,3]) )
+              formatters = ft_printf("%5.15f", [2,3]) )
           end 
 
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number,
@@ -184,7 +184,7 @@ function run(molecule, model; output="none")
             pretty_table(hcat(collect(1:nprim),new_shell_exp, 
               new_shell_coeff), 
               vcat( [ "Primitive" "Exponent" "Contraction Coefficient" ] ),
-              formatters = ft_printf("%5.6f", [2,3]) )
+              formatters = ft_printf("%5.15f", [2,3]) )
           end 
 
           new_shell = JCModules.Shell(shell_id, atom_idx, atomic_number,

--- a/src/modules/BasisStructs.jl
+++ b/src/modules/BasisStructs.jl
@@ -54,7 +54,7 @@ end
   unnormalize::Bool) where {T<:Number}
 
   #== unnormalize basis functions ==#
-  println("UNNORMALIZE") 
+  #println("UNNORMALIZE") 
   unnorm::Float64 = 0.0 
   if unnormalize 
     for iprim::Int64 in 1:nprim
@@ -76,10 +76,10 @@ end
     end
   end
  
-  for icoef in coef
-    @printf("%5.15f\n",icoef)
-  end
-  println("")
+  #for icoef in coef
+  #  @printf("%5.15f\n",icoef)
+  #end
+  #println("")
 
   #=
   println("RENORMALIZE") 

--- a/src/modules/BasisStructs.jl
+++ b/src/modules/BasisStructs.jl
@@ -1,4 +1,4 @@
-#using Printf
+using Printf
 
 struct Shell
   shell_id::Int64
@@ -54,6 +54,7 @@ end
   unnormalize::Bool) where {T<:Number}
 
   #== unnormalize basis functions ==#
+  println("UNNORMALIZE") 
   unnorm::Float64 = 0.0 
   if unnormalize 
     for iprim::Int64 in 1:nprim
@@ -75,7 +76,13 @@ end
     end
   end
  
-  #println("EDITED") 
+  for icoef in coef
+    @printf("%5.15f\n",icoef)
+  end
+  println("")
+
+  #=
+  println("RENORMALIZE") 
   #== renormalize basis functions ==#
   fac::Float64 = 0.0  
   unnorm = 0.0 
@@ -106,11 +113,11 @@ end
    # println(coef[icoef])
   end
 
-  #for icoef in coef
-  #  @printf("%5.10f\n",icoef)
-  #end
-  #println("")
-
+  for icoef in coef
+    @printf("%5.15f, %5.15f\n",icoef, unnorm)
+  end
+  println("")
+  =#
   return create_static_vector_large(coef)
 end
 

--- a/src/rhf/energy/Energy.jl
+++ b/src/rhf/energy/Energy.jl
@@ -35,7 +35,7 @@ scf = RHF.run(input_info, basis)
 ```
 """
 function run(mol::Molecule, basis::Basis, 
-  scf_flags; output="none")
+  scf_flags = Dict(); output="none")
   
   comm=MPI.COMM_WORLD
 

--- a/src/rhf/energy/SCF.jl
+++ b/src/rhf/energy/SCF.jl
@@ -10,14 +10,14 @@ const print_eri = false
 function rhf_energy(mol::Molecule, basis::Basis,
   scf_flags::Union{Dict{String,Any},Dict{Any,Any}}; output)
   
-  debug::Bool = scf_flags["debug"]
-  niter::Int = scf_flags["niter"]
+  debug::Bool = haskey(scf_flags, "debug") ? scf_flags["debug"] : false
+  niter::Int = haskey(scf_flags, "niter") ? scf_flags["niter"] : 50
 
-  ndiis::Int = scf_flags["ndiis"]
-  dele::Float64 = scf_flags["dele"]
-  rmsd::Float64 = scf_flags["rmsd"]
-  load::String = scf_flags["load"]
-  fdiff::Bool = scf_flags["fdiff"]
+  ndiis::Int = haskey(scf_flags, "ndiis") ? scf_flags["ndiis"] : 10
+  dele::Float64 = haskey(scf_flags, "dele") ? scf_flags["dele"] : 1E-5
+  rmsd::Float64 = haskey(scf_flags, "rmsd") ? scf_flags["rmsd"] : 1E-5
+  load::String = haskey(scf_flags, "load") ? scf_flags["load"] : "static"
+  fdiff::Bool = haskey(scf_flags, "fdiff") ? scf_flags["fdiff"] : false
 
   return rhf_kernel(mol,basis; output=output, debug=debug, 
     niter=niter, ndiis=ndiis, dele=dele, rmsd=rmsd, load=load, fdiff=fdiff)

--- a/tools/bse_parse.jl
+++ b/tools/bse_parse.jl
@@ -31,7 +31,7 @@ function parse_individual(atom::Dict{String,Any}, atomid::String, basis::String,
       if shell_type_string == "L"
         s_coeff = parse.(Float64,shell["coefficients"][1])
         p_coeff = parse.(Float64,shell["coefficients"][2])
-        hcat(s_coeff,p_coeff)
+        vcat(s_coeff,p_coeff)
       else
         parse.(Float64,shell["coefficients"][1])
       end


### PR DESCRIPTION
Improvements to the basis set portion of the code, including:

- bsed.h5 now stores coefficients of L shells as single-dimension arrays
- Printout of basis set information is neater and improved

Additionally:

- SCF keywords are now optional, and defaults have been set
- Run scripts have been updated