### PR TITLE
Basis Set Linear Dependence Fix

### DIFF
--- a/src/rhf/energy/SCF.jl
+++ b/src/rhf/energy/SCF.jl
@@ -104,24 +104,29 @@ function rhf_kernel(mol::Molecule,
   workspace_b = similar(F)
   workspace_c = [ similar(F) ]
 
-  #== build the orthogonalization matrix ==#
+  #== check for linear dependencies ==#
+  minimum_eval_threshold = 1.0E-6 
   LinearAlgebra.BLAS.blascopy!(length(S), S, 1, workspace_b, 1)
   #workspace_b .= S
   S_eval_diag, workspace_a[:,:] = eigen!(LinearAlgebra.Hermitian(workspace_b))
 
   #fill!(workspace_b, 0.0)
-  LinearAlgebra.BLAS.scal!(length(workspace_b), 0.0, workspace_b, 1) 
+  #LinearAlgebra.BLAS.scal!(length(workspace_b), 0.0, workspace_b, 1) 
+  
   for i in 1:basis.norb
     workspace_b[i,i] = S_eval_diag[i]
   end
- 
-  
+
+  S_good_evals = findall(eval -> eval >= minimum_eval_threshold, S_eval_diag)  
   #ortho = similar(F)
   #LinearAlgebra.BLAS.gemm!('N', 'T', 1.0, 
   #  workspace_b, workspace_a, 0.0, ortho)
   #LinearAlgebra.BLAS.gemm!('N', 'N', 1.0, workspace_a, ortho, 0.0, ortho) 
  
-  ortho = workspace_a*(LinearAlgebra.Diagonal(workspace_b)^-0.5)*transpose(workspace_a)
+  #== build the orthogonalization matrix ==#
+  @views ortho = workspace_a[1:end,S_good_evals]*
+    (LinearAlgebra.Diagonal(workspace_b[S_good_evals,S_good_evals])^-0.5)*
+    transpose(workspace_a[1:end, S_good_evals])
   
   if debug && MPI.Comm_rank(comm) == 0
     h5write("debug.h5","RHF/Iteration-None/X", ortho)

--- a/src/rhf/energy/SCF.jl
+++ b/src/rhf/energy/SCF.jl
@@ -111,8 +111,7 @@ function rhf_kernel(mol::Molecule,
   S_eval_diag, workspace_a[:,:] = eigen!(LinearAlgebra.Hermitian(workspace_b))
 
   #fill!(workspace_b, 0.0)
-  #LinearAlgebra.BLAS.scal!(length(workspace_b), 0.0, workspace_b, 1) 
-  
+  LinearAlgebra.BLAS.scal!(length(workspace_b), 0.0, workspace_b, 1) 
   for i in 1:basis.norb
     workspace_b[i,i] = S_eval_diag[i]
   end


### PR DESCRIPTION
Added code to enable checking and accounting for instances of basis set linear dependence in the construction of the orthogonalization matrix. The code will now check for such linear dependencies and remove them as the orthogonalization matrix is made.